### PR TITLE
Expose burndown people

### DIFF
--- a/burndown.go
+++ b/burndown.go
@@ -78,6 +78,10 @@ type BurndownResult struct {
 	granularity        int
 }
 
+func (r *BurndownResult) GetPeople() []string {
+	return r.reversedPeopleDict
+}
+
 const (
 	ConfigBurndownGranularity  = "Burndown.Granularity"
 	ConfigBurndownSampling     = "Burndown.Sampling"


### PR DESCRIPTION
I don't use serializer of hercules to reduce payload size. But the list of people is inaccessible now.