### PR TITLE
Add parameter to skip vendor directories

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   GOPATH: c:\gopath
 
 install:
-  - choco install make
+  - choco install --allow-empty-checksums make
   - c:\msys64\usr\bin\pacman --noconfirm --needed -S mingw-w64-x86_64-toolchain
   - curl -SLko protoc.zip https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-win32.zip
   - 7z e protoc.zip

--- a/pipeline.go
+++ b/pipeline.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"gopkg.in/src-d/go-git.v4"
@@ -31,6 +32,8 @@ const (
 	StringConfigurationOption
 	// FloatConfigurationOption reflects a floating point value type.
 	FloatConfigurationOption
+	// StringsConfigurationOption reflects the array of strings value type.
+	StringsConfigurationOption
 )
 
 // String() returns an empty string for the boolean type, "int" for integers and "string" for
@@ -45,6 +48,8 @@ func (opt ConfigurationOptionType) String() string {
 		return "string"
 	case FloatConfigurationOption:
 		return "float"
+	case StringsConfigurationOption:
+		return "string"
 	}
 	panic(fmt.Sprintf("Invalid ConfigurationOptionType value %d", opt))
 }
@@ -66,6 +71,9 @@ type ConfigurationOption struct {
 // FormatDefault converts the default value of ConfigurationOption to string.
 // Used in the command line interface to show the argument's default value.
 func (opt ConfigurationOption) FormatDefault() string {
+	if opt.Type == StringsConfigurationOption {
+		return fmt.Sprintf("\"%s\"", strings.Join(opt.Default.([]string), ","))
+	}
 	if opt.Type != StringConfigurationOption {
 		return fmt.Sprint(opt.Default)
 	}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -423,6 +423,8 @@ func TestConfigurationOptionTypeString(t *testing.T) {
 	opt = ConfigurationOptionType(3)
 	assert.Equal(t, opt.String(), "float")
 	opt = ConfigurationOptionType(4)
+	assert.Equal(t, opt.String(), "string")
+	opt = ConfigurationOptionType(5)
 	assert.Panics(t, func() { _ = opt.String() })
 }
 

--- a/registry.go
+++ b/registry.go
@@ -180,6 +180,10 @@ func (registry *PipelineItemRegistry) AddFlags(flagSet *pflag.FlagSet) (
 				iface = interface{}(float32(0))
 				ptr := (**float32)(getPtr())
 				*ptr = flagSet.Float32(opt.Flag, opt.Default.(float32), formatHelp(opt.Description))
+			case StringsConfigurationOption:
+				iface = interface{}([]string{})
+				ptr := (**[]string)(getPtr())
+				*ptr = flagSet.StringSlice(opt.Flag, opt.Default.([]string), formatHelp(opt.Description))
 			}
 			flags[opt.Name] = iface
 		}

--- a/tree_diff.go
+++ b/tree_diff.go
@@ -54,8 +54,8 @@ func (treediff *TreeDiff) Requires() []string {
 func (treediff *TreeDiff) ListConfigurationOptions() []ConfigurationOption {
 	options := [...]ConfigurationOption{{
 		Name:        ConfigTreeDiffEnableBlacklist,
-		Description: "Enable blacklisted directories.",
-		Flag:        "enable-blacklist",
+		Description: "Skip blacklisted directories.",
+		Flag:        "skip-blacklist",
 		Type:        BoolConfigurationOption,
 		Default:     false}, {
 		Name:        ConfigTreeDiffBlacklistedDirs,

--- a/tree_diff.go
+++ b/tree_diff.go
@@ -13,18 +13,18 @@ import (
 // If "after" is nil, the change is a removal. Otherwise, it is a modification.
 // TreeDiff is a PipelineItem.
 type TreeDiff struct {
-	previousTree *object.Tree
 	SkipDirs     []string
+	previousTree *object.Tree
 }
 
 const (
 	// DependencyTreeChanges is the name of the dependency provided by TreeDiff.
 	DependencyTreeChanges = "changes"
-	// ConfigTreeDiffSkipBlacklist is the name of the configuration option
-	// (TreeDiff.Configure()) which allows to skip blacklist directories.
-	ConfigTreeDiffSkipBlacklist = "TreeDiff.SkipVendor"
+	// ConfigTreeDiffEnableBlacklist is the name of the configuration option
+	// (TreeDiff.Configure()) which allows to skip blacklisted directories.
+	ConfigTreeDiffEnableBlacklist = "TreeDiff.EnableBlacklist"
 	// ConfigTreeDiffBlacklistedDirs s the name of the configuration option
-	// (TreeDiff.Configure()) which allows to set blacklist directories.
+	// (TreeDiff.Configure()) which allows to set blacklisted directories.
 	ConfigTreeDiffBlacklistedDirs = "TreeDiff.BlacklistedDirs"
 )
 
@@ -53,13 +53,13 @@ func (treediff *TreeDiff) Requires() []string {
 // ListConfigurationOptions returns the list of changeable public properties of this PipelineItem.
 func (treediff *TreeDiff) ListConfigurationOptions() []ConfigurationOption {
 	options := [...]ConfigurationOption{{
-		Name:        ConfigTreeDiffSkipBlacklist,
-		Description: "Skip blacklist directories.",
-		Flag:        "skip-blacklist",
+		Name:        ConfigTreeDiffEnableBlacklist,
+		Description: "Enable blacklisted directories.",
+		Flag:        "enable-blacklist",
 		Type:        BoolConfigurationOption,
 		Default:     false}, {
 		Name:        ConfigTreeDiffBlacklistedDirs,
-		Description: "List of blacklist directories. Separated by comma \",\".",
+		Description: "List of blacklisted directories. Separated by comma \",\".",
 		Flag:        "blacklisted-dirs",
 		Type:        StringsConfigurationOption,
 		Default:     defaultBlacklistedDirs},
@@ -69,7 +69,7 @@ func (treediff *TreeDiff) ListConfigurationOptions() []ConfigurationOption {
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (treediff *TreeDiff) Configure(facts map[string]interface{}) {
-	if val, exists := facts[ConfigTreeDiffSkipBlacklist]; exists && val.(bool) == true {
+	if val, exist := facts[ConfigTreeDiffEnableBlacklist]; exist && val.(bool) {
 		treediff.SkipDirs = facts[ConfigTreeDiffBlacklistedDirs].([]string)
 	}
 }

--- a/tree_diff.go
+++ b/tree_diff.go
@@ -2,6 +2,7 @@ package hercules
 
 import (
 	"io"
+	"strings"
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
@@ -13,12 +14,21 @@ import (
 // TreeDiff is a PipelineItem.
 type TreeDiff struct {
 	previousTree *object.Tree
+	SkipDirs     []string
 }
 
 const (
 	// DependencyTreeChanges is the name of the dependency provided by TreeDiff.
 	DependencyTreeChanges = "changes"
+	// ConfigTreeDiffSkipBlacklist is the name of the configuration option
+	// (TreeDiff.Configure()) which allows to skip blacklist directories.
+	ConfigTreeDiffSkipBlacklist = "TreeDiff.SkipVendor"
+	// ConfigTreeDiffBlacklistedDirs s the name of the configuration option
+	// (TreeDiff.Configure()) which allows to set blacklist directories.
+	ConfigTreeDiffBlacklistedDirs = "TreeDiff.BlacklistedDirs"
 )
+
+var defaultBlacklistedDirs = []string{"vendor/", "vendors/", "node_modules/"}
 
 // Name of this PipelineItem. Uniquely identifies the type, used for mapping keys, etc.
 func (treediff *TreeDiff) Name() string {
@@ -42,11 +52,27 @@ func (treediff *TreeDiff) Requires() []string {
 
 // ListConfigurationOptions returns the list of changeable public properties of this PipelineItem.
 func (treediff *TreeDiff) ListConfigurationOptions() []ConfigurationOption {
-	return []ConfigurationOption{}
+	options := [...]ConfigurationOption{{
+		Name:        ConfigTreeDiffSkipBlacklist,
+		Description: "Skip blacklist directories.",
+		Flag:        "skip-blacklist",
+		Type:        BoolConfigurationOption,
+		Default:     false}, {
+		Name:        ConfigTreeDiffBlacklistedDirs,
+		Description: "List of blacklist directories. Separated by comma \",\".",
+		Flag:        "blacklisted-dirs",
+		Type:        StringsConfigurationOption,
+		Default:     defaultBlacklistedDirs},
+	}
+	return options[:]
 }
 
 // Configure sets the properties previously published by ListConfigurationOptions().
-func (treediff *TreeDiff) Configure(facts map[string]interface{}) {}
+func (treediff *TreeDiff) Configure(facts map[string]interface{}) {
+	if val, exists := facts[ConfigTreeDiffSkipBlacklist]; exists && val.(bool) == true {
+		treediff.SkipDirs = facts[ConfigTreeDiffBlacklistedDirs].([]string)
+	}
+}
 
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
@@ -95,6 +121,22 @@ func (treediff *TreeDiff) Consume(deps map[string]interface{}) (map[string]inter
 		}
 	}
 	treediff.previousTree = tree
+
+	if len(treediff.SkipDirs) > 0 {
+		// filter without allocation
+		filteredDiff := diff[:0]
+	OUTER:
+		for _, change := range diff {
+			for _, dir := range treediff.SkipDirs {
+				if strings.HasPrefix(change.To.Name, dir) || strings.HasPrefix(change.From.Name, dir) {
+					continue OUTER
+				}
+			}
+			filteredDiff = append(filteredDiff, change)
+		}
+
+		diff = filteredDiff
+	}
 	return map[string]interface{}{DependencyTreeChanges: diff}, nil
 }
 

--- a/tree_diff_test.go
+++ b/tree_diff_test.go
@@ -23,7 +23,7 @@ func TestTreeDiffMeta(t *testing.T) {
 	assert.Equal(t, len(td.Provides()), 1)
 	assert.Equal(t, td.Provides()[0], DependencyTreeChanges)
 	opts := td.ListConfigurationOptions()
-	assert.Len(t, opts, 0)
+	assert.Len(t, opts, 2)
 }
 
 func TestTreeDiffRegistration(t *testing.T) {

--- a/tree_diff_test.go
+++ b/tree_diff_test.go
@@ -131,7 +131,7 @@ func TestTreeDiffConsumeSkip(t *testing.T) {
 	td = fixtureTreeDiff()
 	td.previousTree, _ = prevCommit.Tree()
 	td.Configure(map[string]interface{}{
-		ConfigTreeDiffSkipBlacklist:   true,
+		ConfigTreeDiffEnableBlacklist: true,
 		ConfigTreeDiffBlacklistedDirs: []string{"vendor/"},
 	})
 	res, err = td.Consume(deps)


### PR DESCRIPTION
In golang it's common practice to commit vendor directory. In other languages, people do it sometimes too.

It messes up results of analysis a lot. This option allows to skip files which start with most popular prefixes `vendor/`, `vendors/`, `node_modules/`.