### PR TITLE
Delete dco.yml

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,0 @@
-require:
-  members: false


### PR DESCRIPTION
The requirement to DCO should be always done for source code repositories. 

Signed-off-by: Máximo Cuadros <mcuadros@gmail.com>