### PR TITLE
Enable race detection on test run, fix race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ cmd/hercules/plugin_template_source.go
 contrib/_plugin_example/churn_analysis.pb.go
 pb/pb.pb.go
 pb/pb_pb2.py
+coverage.txt
 
 **/.DS_Store
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ script:
   - golint -set_exit_status $(go list ./... | grep -v /vendor/)
   - flake8
   - go test -coverpkg=all -v -coverprofile=coverage.txt -covermode=count gopkg.in/src-d/hercules.v9/... && sed -i '/cmd\/hercules\|core.go/d' coverage.txt
+  - go test -race gopkg.in/src-d/hercules.v9/... # run race test separately to preserve -covermode=count
   - $GOPATH/bin/hercules version
   - $GOPATH/bin/hercules --burndown --couples --devs --quiet --pb https://github.com/src-d/hercules > 1.pb
   - cp 1.pb 2.pb

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,0 +1,1 @@
+mode: atomic

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,1 +1,0 @@
-mode: atomic


### PR DESCRIPTION
Please feel free to close this if avoiding race conditions aren't a priority, but I noticed my `-race`-enabled tests would fail on what seemed like hercules code.

If the build for this PR fails (it does locally on my machine) I'll open a ticket about resolving concurrency issues.

Here's what I get when I run hercules' tests on my machine:

```
WARNING: DATA RACE
Write at 0x00c0001f2928 by goroutine 42:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume.func1.1()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:215 +0x38
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume.func1()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:267 +0x1036
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume.func3()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:327 +0x38

Previous write at 0x00c0001f2928 by goroutine 43:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume.func2.1()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:271 +0x38
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume.func2()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:322 +0x103b
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume.func4()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:328 +0x38

Goroutine 42 (running) created at:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:327 +0x2526
  gopkg.in/src-d/hercules.v9/internal/plumbing.TestRenameAnalysisConsume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames_test.go:126 +0xb26
  testing.tRunner()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:865 +0x163

Goroutine 43 (finished) created at:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:328 +0x2558
  gopkg.in/src-d/hercules.v9/internal/plumbing.TestRenameAnalysisConsume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames_test.go:126 +0xb26
  testing.tRunner()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:865 +0x163
==================
==================
WARNING: DATA RACE
Write at 0x00c00015d080 by goroutine 42:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume.func3()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:327 +0x59

Previous write at 0x00c00015d080 by goroutine 43:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume.func4()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:328 +0x59

Goroutine 42 (running) created at:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:327 +0x2526
  gopkg.in/src-d/hercules.v9/internal/plumbing.TestRenameAnalysisConsume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames_test.go:126 +0xb26
  testing.tRunner()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:865 +0x163

Goroutine 43 (finished) created at:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:328 +0x2558
  gopkg.in/src-d/hercules.v9/internal/plumbing.TestRenameAnalysisConsume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames_test.go:126 +0xb26
  testing.tRunner()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:865 +0x163
==================
==================
WARNING: DATA RACE
Read at 0x00c00015d080 by goroutine 41:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:330 +0x257a
  gopkg.in/src-d/hercules.v9/internal/plumbing.TestRenameAnalysisConsume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames_test.go:126 +0xb26
  testing.tRunner()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:865 +0x163

Previous write at 0x00c00015d080 by goroutine 43:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume.func4()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:328 +0x59

Goroutine 41 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:916 +0x699
  testing.runTests.func1()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:170 +0x222

Goroutine 43 (finished) created at:
  gopkg.in/src-d/hercules.v9/internal/plumbing.(*RenameAnalysis).Consume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames.go:328 +0x2558
  gopkg.in/src-d/hercules.v9/internal/plumbing.TestRenameAnalysisConsume()
      /Users/robertlin/go/src/gopkg.in/src-d/hercules.v9/internal/plumbing/renames_test.go:126 +0xb26
  testing.tRunner()
      /usr/local/Cellar/go/1.12/libexec/src/testing/testing.go:865 +0x163
==================
```

**update**: travis [ran into the same issue](https://travis-ci.com/src-d/hercules/jobs/183178481#L1331), so I've opened #233 with some more details

**update 2**: working on resolving race conditions, so hopefully this will close #233 as well