### PR TITLE
Expose plumbing.ConfigTicksSinceStartTickSize

### DIFF
--- a/core.go
+++ b/core.go
@@ -79,6 +79,8 @@ const (
 	// ConfigPipelineCommits is the name of the Pipeline configuration option (Pipeline.Initialize())
 	// which allows to specify the custom commit sequence. By default, Pipeline.Commits() is used.
 	ConfigPipelineCommits = core.ConfigPipelineCommits
+	// ConfigTickSize is the number of hours per 'tick'
+	ConfigTickSize = plumbing.ConfigTicksSinceStartTickSize
 )
 
 // NewPipeline initializes a new instance of Pipeline struct.


### PR DESCRIPTION
follow-up to #245 

not sure if this is the right way to do this, but as it is right now there's no way to configure tick size programmatically short of something like:

```go
	g.pipe.Initialize(map[string]interface{}{
		leaves.ConfigBurndownTrackPeople: true,
		"TicksSinceStart.TickSize":       48,
	})
```

which feels a little uncomfortable 😋 this PR allows the following:

```go
	g.pipe.Initialize(map[string]interface{}{
		leaves.ConfigBurndownTrackPeople: true,
		hercules.ConfigTickSize:          48,
	})
```