### PR TITLE
Add pluggable Logger for pipeline

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -277,9 +277,12 @@
   revision = "f187355171c936ac84a82793659ebb4936bc1c23"
 
 [[projects]]
-  digest = "1:e7e3141ecc5f7eeae9a1a4438044614049ccdd57a302b8793dec0c29202cadce"
+  digest = "1:c5cc4981dbab46f68150ea9772532a7c26f8109112c7302d7cc0a5011eef3276"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require",
+  ]
   pruneopts = "UT"
   revision = "5b93e2dc01fd8fbf32aa74a198b0ebe78f6f6b6f"
 
@@ -632,6 +635,7 @@
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
     "golang.org/x/crypto/ssh/terminal",
     "gopkg.in/bblfsh/client-go.v3",
     "gopkg.in/bblfsh/client-go.v3/tools",

--- a/cmd/hercules/plugin.template
+++ b/cmd/hercules/plugin.template
@@ -34,6 +34,8 @@ type {{.name}} struct {
   hercules.NoopMerger
   // Process each merge commit only once
   hercules.OneShotMergeProcessor
+  // Logger for consistent output
+  l hercules.Logger
 }
 
 // {{.name}}Result is returned by Finalize() and represents the analysis result.
@@ -81,11 +83,17 @@ func ({{.varname}} *{{.name}}) Description() string {
 
 // Configure applies the parameters specified in the command line. Map keys correspond to "Name".
 func ({{.varname}} *{{.name}}) Configure(facts map[string]interface{}) error {
+  if l, exists := facts[hercules.ConfigLogger].(hercules.Logger); exists {
+		{{.varname}}.l = l
+	}
   return nil
 }
 
 // Initialize resets the internal temporary data structures and prepares the object for Consume().
 func ({{.varname}} *{{.name}}) Initialize(repository *git.Repository) error {
+  if {{.varname}}.l == nil {
+    l = hercules.NewLogger()
+  }
   {{.varname}}.OneShotMergeProcessor.Initialize()
   return nil
 }

--- a/cmd/hercules/plugin.template
+++ b/cmd/hercules/plugin.template
@@ -84,8 +84,8 @@ func ({{.varname}} *{{.name}}) Description() string {
 // Configure applies the parameters specified in the command line. Map keys correspond to "Name".
 func ({{.varname}} *{{.name}}) Configure(facts map[string]interface{}) error {
   if l, exists := facts[hercules.ConfigLogger].(hercules.Logger); exists {
-		{{.varname}}.l = l
-	}
+    {{.varname}}.l = l
+  }
   return nil
 }
 

--- a/cmd/hercules/plugin.template
+++ b/cmd/hercules/plugin.template
@@ -91,9 +91,7 @@ func ({{.varname}} *{{.name}}) Configure(facts map[string]interface{}) error {
 
 // Initialize resets the internal temporary data structures and prepares the object for Consume().
 func ({{.varname}} *{{.name}}) Initialize(repository *git.Repository) error {
-  if {{.varname}}.l == nil {
-    {{.varname}}.l = hercules.NewLogger()
-  }
+  {{.varname}}.l = hercules.NewLogger()
   {{.varname}}.OneShotMergeProcessor.Initialize()
   return nil
 }

--- a/cmd/hercules/plugin.template
+++ b/cmd/hercules/plugin.template
@@ -92,7 +92,7 @@ func ({{.varname}} *{{.name}}) Configure(facts map[string]interface{}) error {
 // Initialize resets the internal temporary data structures and prepares the object for Consume().
 func ({{.varname}} *{{.name}}) Initialize(repository *git.Repository) error {
   if {{.varname}}.l == nil {
-    l = hercules.NewLogger()
+    {{.varname}}.l = hercules.NewLogger()
   }
   {{.varname}}.OneShotMergeProcessor.Initialize()
   return nil

--- a/contrib/_plugin_example/churn_analysis.go
+++ b/contrib/_plugin_example/churn_analysis.go
@@ -30,6 +30,8 @@ type ChurnAnalysis struct {
 
 	// references IdentityDetector.ReversedPeopleDict
 	reversedPeopleDict []string
+
+	l hercules.Logger
 }
 
 type editInfo struct {
@@ -105,6 +107,9 @@ func (churn *ChurnAnalysis) Description() string {
 
 // Configure applies the parameters specified in the command line. Map keys correspond to "Name".
 func (churn *ChurnAnalysis) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[hercules.ConfigLogger].(hercules.Logger); exists {
+		churn.l = l
+	}
 	if val, exists := facts[ConfigChurnTrackPeople].(bool); exists {
 		churn.TrackPeople = val
 	}
@@ -116,6 +121,7 @@ func (churn *ChurnAnalysis) Configure(facts map[string]interface{}) error {
 
 // Initialize resets the internal temporary data structures and prepares the object for Consume().
 func (churn *ChurnAnalysis) Initialize(repository *git.Repository) error {
+	churn.l = hercules.NewLogger()
 	churn.global = []editInfo{}
 	churn.people = map[int][]editInfo{}
 	churn.OneShotMergeProcessor.Initialize()

--- a/core.go
+++ b/core.go
@@ -81,6 +81,8 @@ const (
 	ConfigPipelineCommits = core.ConfigPipelineCommits
 	// ConfigTickSize is the number of hours per 'tick'
 	ConfigTickSize = plumbing.ConfigTicksSinceStartTickSize
+	// ConfigLogger is used to set the logger in all pipeline items.
+	ConfigLogger = core.ConfigLogger
 )
 
 // NewPipeline initializes a new instance of Pipeline struct.
@@ -174,3 +176,9 @@ func PathifyFlagValue(flag *pflag.Flag) {
 func EnablePathFlagTypeMasquerade() {
 	core.EnablePathFlagTypeMasquerade()
 }
+
+// Logger is the Hercules logging interface
+type Logger core.Logger
+
+// NewLogger returns an instance of the default Hercules logger
+func NewLogger() core.Logger { return core.NewLogger() }

--- a/doc.go
+++ b/doc.go
@@ -37,6 +37,15 @@ Finally extract the result:
 
 The actual usage example is cmd/hercules/root.go - the command line tool's code.
 
+You can provide additional options via `facts` on initialization. For example,
+to provide your own logger, enable people-tracking, and set a custom tick size:
+
+  pipe.Initialize(map[string]interface{}{
+    hercules.ConfigLogger:            zap.NewExample().Sugar(),
+    hercules.ConfigTickSize:          12,
+    leaves.ConfigBurndownTrackPeople: true,
+  })
+
 Hercules depends heavily on https://github.com/src-d/go-git and leverages the
 diff algorithm through https://github.com/sergi/go-diff.
 

--- a/internal/core/logger.go
+++ b/internal/core/logger.go
@@ -37,25 +37,26 @@ func NewLogger() *DefaultLogger {
 	}
 }
 
-// Info writes to info logger
+// Info writes to "info" logger.
 func (d *DefaultLogger) Info(v ...interface{}) { d.I.Println(v...) }
 
-// Infof writes to info logger
+// Infof writes to "info" logger with printf-style formatting.
 func (d *DefaultLogger) Infof(f string, v ...interface{}) { d.I.Printf(f, v...) }
 
-// Warn writes to the warning logger
+// Warn writes to the "warning" logger.
 func (d *DefaultLogger) Warn(v ...interface{}) { d.W.Println(v...) }
 
-// Warnf writes to the warning logger
+// Warnf writes to the "warning" logger with printf-style formatting.
 func (d *DefaultLogger) Warnf(f string, v ...interface{}) { d.W.Printf(f, v...) }
 
-// Error writes to the error logger
+// Error writes to the "error" logger and logs the current stacktrace.
 func (d *DefaultLogger) Error(v ...interface{}) {
 	d.E.Println(v...)
 	d.logStacktraceToErr()
 }
 
-// Errorf writes to the error logger
+// Errorf writes to the "error" logger with printf-style formatting and logs the
+// current stacktrace.
 func (d *DefaultLogger) Errorf(f string, v ...interface{}) {
 	d.E.Printf(f, v...)
 	d.logStacktraceToErr()

--- a/internal/core/logger.go
+++ b/internal/core/logger.go
@@ -75,5 +75,9 @@ func (d *DefaultLogger) logStacktraceToErr() {
 func captureStacktrace(skip int) []string {
 	stack := string(debug.Stack())
 	lines := strings.Split(stack, "\n")
-	return lines[2*skip+1:]
+	linesToSkip := 2*skip + 1
+	if linesToSkip > len(lines) {
+		return lines
+	}
+	return lines[linesToSkip:]
 }

--- a/internal/core/logger.go
+++ b/internal/core/logger.go
@@ -31,8 +31,8 @@ type DefaultLogger struct {
 // NewLogger returns a configured default logger.
 func NewLogger() *DefaultLogger {
 	return &DefaultLogger{
-		I: log.New(os.Stdout, "[INFO] ", log.LstdFlags),
-		W: log.New(os.Stdout, "[WARN] ", log.LstdFlags),
+		I: log.New(os.Stderr, "[INFO] ", log.LstdFlags),
+		W: log.New(os.Stderr, "[WARN] ", log.LstdFlags),
 		E: log.New(os.Stderr, "[ERROR] ", log.LstdFlags),
 	}
 }

--- a/internal/core/logger.go
+++ b/internal/core/logger.go
@@ -69,7 +69,7 @@ func (d *DefaultLogger) Errorf(f string, v ...interface{}) {
 // * DefaultLogger::logStacktraceToErr()
 // * DefaultLogger::Error() or DefaultLogger::Errorf()
 func (d *DefaultLogger) logStacktraceToErr() {
-	d.E.Println("stacktrace:\n" + strings.Join(captureStacktrace(0), "\n"))
+	d.E.Println("stacktrace:\n" + strings.Join(captureStacktrace(4), "\n"))
 }
 
 func captureStacktrace(skip int) []string {

--- a/internal/core/logger.go
+++ b/internal/core/logger.go
@@ -41,13 +41,13 @@ func NewLogger() *DefaultLogger {
 func (d *DefaultLogger) Info(v ...interface{}) { d.I.Println(v...) }
 
 // Infof writes to info logger
-func (d *DefaultLogger) Infof(f string, v ...interface{}) { d.I.Printf(f+"\n", v...) }
+func (d *DefaultLogger) Infof(f string, v ...interface{}) { d.I.Printf(f, v...) }
 
 // Warn writes to the warning logger
 func (d *DefaultLogger) Warn(v ...interface{}) { d.W.Println(v...) }
 
 // Warnf writes to the warning logger
-func (d *DefaultLogger) Warnf(f string, v ...interface{}) { d.W.Printf(f+"\n", v...) }
+func (d *DefaultLogger) Warnf(f string, v ...interface{}) { d.W.Printf(f, v...) }
 
 // Error writes to the error logger
 func (d *DefaultLogger) Error(v ...interface{}) {
@@ -57,7 +57,7 @@ func (d *DefaultLogger) Error(v ...interface{}) {
 
 // Errorf writes to the error logger
 func (d *DefaultLogger) Errorf(f string, v ...interface{}) {
-	d.E.Printf(f+"\n", v...)
+	d.E.Printf(f, v...)
 	d.logStacktraceToErr()
 }
 

--- a/internal/core/logger.go
+++ b/internal/core/logger.go
@@ -18,6 +18,8 @@ type Logger interface {
 	Warnf(string, ...interface{})
 	Error(...interface{})
 	Errorf(string, ...interface{})
+	Critical(...interface{})
+	Criticalf(string, ...interface{})
 }
 
 // DefaultLogger is the default logger used by a pipeline, and wraps the standard
@@ -49,15 +51,21 @@ func (d *DefaultLogger) Warn(v ...interface{}) { d.W.Println(v...) }
 // Warnf writes to the "warning" logger with printf-style formatting.
 func (d *DefaultLogger) Warnf(f string, v ...interface{}) { d.W.Printf(f, v...) }
 
-// Error writes to the "error" logger and logs the current stacktrace.
-func (d *DefaultLogger) Error(v ...interface{}) {
+// Error writes to the "error" logger.
+func (d *DefaultLogger) Error(v ...interface{}) { d.E.Println(v...) }
+
+// Errorf writes to the "error" logger with printf-style formatting.
+func (d *DefaultLogger) Errorf(f string, v ...interface{}) { d.E.Printf(f, v...) }
+
+// Critical writes to the "error" logger and logs the current stacktrace.
+func (d *DefaultLogger) Critical(v ...interface{}) {
 	d.E.Println(v...)
 	d.logStacktraceToErr()
 }
 
-// Errorf writes to the "error" logger with printf-style formatting and logs the
+// Criticalf writes to the "error" logger with printf-style formatting and logs the
 // current stacktrace.
-func (d *DefaultLogger) Errorf(f string, v ...interface{}) {
+func (d *DefaultLogger) Criticalf(f string, v ...interface{}) {
 	d.E.Printf(f, v...)
 	d.logStacktraceToErr()
 }

--- a/internal/core/logger.go
+++ b/internal/core/logger.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"log"
+	"os"
+)
+
+// Logger defines the output interface used by Hercules components.
+type Logger interface {
+	Info(...interface{})
+	Infof(string, ...interface{})
+	Warn(...interface{})
+	Warnf(string, ...interface{})
+	Error(...interface{})
+	Errorf(string, ...interface{})
+}
+
+// DefaultLogger is the default logger used by a pipeline, and wraps the standard
+// log library.
+type DefaultLogger struct {
+	I *log.Logger
+	W *log.Logger
+	E *log.Logger
+}
+
+// NewLogger returns a configured default logger.
+func NewLogger() *DefaultLogger {
+	return &DefaultLogger{
+		I: log.New(os.Stdout, "[INFO] ", log.LstdFlags),
+		W: log.New(os.Stdout, "[WARN] ", log.LstdFlags),
+		E: log.New(os.Stderr, "[ERROR] ", log.LstdFlags),
+	}
+}
+
+// Info writes to info logger
+func (d *DefaultLogger) Info(v ...interface{}) { d.I.Print(v...) }
+
+// Infof writes to info logger
+func (d *DefaultLogger) Infof(f string, v ...interface{}) { d.I.Printf(f, v...) }
+
+// Warn writes to the warning logger
+func (d *DefaultLogger) Warn(v ...interface{}) { d.W.Print(v...) }
+
+// Warnf writes to the warning logger
+func (d *DefaultLogger) Warnf(f string, v ...interface{}) { d.W.Printf(f, v...) }
+
+// Error writes to the error logger
+func (d *DefaultLogger) Error(v ...interface{}) { d.E.Print(v...) }
+
+// Errorf writes to the error logger
+func (d *DefaultLogger) Errorf(f string, v ...interface{}) { d.E.Printf(f, v...) }

--- a/internal/core/logger.go
+++ b/internal/core/logger.go
@@ -38,26 +38,26 @@ func NewLogger() *DefaultLogger {
 }
 
 // Info writes to info logger
-func (d *DefaultLogger) Info(v ...interface{}) { d.I.Print(v...) }
+func (d *DefaultLogger) Info(v ...interface{}) { d.I.Println(v...) }
 
 // Infof writes to info logger
-func (d *DefaultLogger) Infof(f string, v ...interface{}) { d.I.Printf(f, v...) }
+func (d *DefaultLogger) Infof(f string, v ...interface{}) { d.I.Printf(f+"\n", v...) }
 
 // Warn writes to the warning logger
-func (d *DefaultLogger) Warn(v ...interface{}) { d.W.Print(v...) }
+func (d *DefaultLogger) Warn(v ...interface{}) { d.W.Println(v...) }
 
 // Warnf writes to the warning logger
-func (d *DefaultLogger) Warnf(f string, v ...interface{}) { d.W.Printf(f, v...) }
+func (d *DefaultLogger) Warnf(f string, v ...interface{}) { d.W.Printf(f+"\n", v...) }
 
 // Error writes to the error logger
 func (d *DefaultLogger) Error(v ...interface{}) {
-	d.E.Print(v...)
+	d.E.Println(v...)
 	d.logStacktraceToErr()
 }
 
 // Errorf writes to the error logger
 func (d *DefaultLogger) Errorf(f string, v ...interface{}) {
-	d.E.Printf(f, v...)
+	d.E.Printf(f+"\n", v...)
 	d.logStacktraceToErr()
 }
 

--- a/internal/core/logger.go
+++ b/internal/core/logger.go
@@ -5,6 +5,9 @@ import (
 	"os"
 )
 
+// ConfigLogger is the key for the pipeline's logger
+const ConfigLogger = "Core.Logger"
+
 // Logger defines the output interface used by Hercules components.
 type Logger interface {
 	Info(...interface{})

--- a/internal/core/logger_test.go
+++ b/internal/core/logger_test.go
@@ -34,19 +34,24 @@ func TestLogger(t *testing.T) {
 
 	l.Warn(v...)
 	assert.Contains(t, wBuf.String(), "[WARN]")
-	iBuf.Reset()
+	wBuf.Reset()
 
 	l.Warnf(f, v...)
 	assert.Contains(t, wBuf.String(), "[WARN]")
 	assert.Contains(t, wBuf.String(), "-")
-	iBuf.Reset()
+	wBuf.Reset()
 
 	l.Error(v...)
 	assert.Contains(t, eBuf.String(), "[ERROR]")
-	iBuf.Reset()
+	assert.Contains(t, eBuf.String(), "internal/core.TestLogger")
+	assert.Contains(t, eBuf.String(), "internal/core/logger_test.go:44")
+	eBuf.Reset()
 
 	l.Errorf(f, v...)
 	assert.Contains(t, eBuf.String(), "[ERROR]")
 	assert.Contains(t, eBuf.String(), "-")
-	iBuf.Reset()
+	assert.Contains(t, eBuf.String(), "internal/core.TestLogger")
+	assert.Contains(t, eBuf.String(), "internal/core/logger_test.go:50")
+	println(eBuf.String())
+	eBuf.Reset()
 }

--- a/internal/core/logger_test.go
+++ b/internal/core/logger_test.go
@@ -43,15 +43,24 @@ func TestLogger(t *testing.T) {
 
 	l.Error(v...)
 	assert.Contains(t, eBuf.String(), "[ERROR]")
-	assert.Contains(t, eBuf.String(), "internal/core.TestLogger")
-	assert.Contains(t, eBuf.String(), "internal/core/logger_test.go:44")
 	eBuf.Reset()
 
 	l.Errorf(f, v...)
 	assert.Contains(t, eBuf.String(), "[ERROR]")
 	assert.Contains(t, eBuf.String(), "-")
+	eBuf.Reset()
+
+	l.Critical(v...)
+	assert.Contains(t, eBuf.String(), "[ERROR]")
 	assert.Contains(t, eBuf.String(), "internal/core.TestLogger")
-	assert.Contains(t, eBuf.String(), "internal/core/logger_test.go:50")
+	assert.Contains(t, eBuf.String(), "internal/core/logger_test.go:53")
+	eBuf.Reset()
+
+	l.Criticalf(f, v...)
+	assert.Contains(t, eBuf.String(), "[ERROR]")
+	assert.Contains(t, eBuf.String(), "-")
+	assert.Contains(t, eBuf.String(), "internal/core.TestLogger")
+	assert.Contains(t, eBuf.String(), "internal/core/logger_test.go:59")
 	println(eBuf.String())
 	eBuf.Reset()
 }

--- a/internal/core/logger_test.go
+++ b/internal/core/logger_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogger(t *testing.T) {
+	var (
+		f = "%s-%s"
+		v = []interface{}{"hello", "world"}
+		l = NewLogger()
+
+		iBuf bytes.Buffer
+		wBuf bytes.Buffer
+		eBuf bytes.Buffer
+	)
+
+	// capture output
+	l.I.SetOutput(&iBuf)
+	l.W.SetOutput(&wBuf)
+	l.E.SetOutput(&eBuf)
+
+	l.Info(v...)
+	assert.Contains(t, iBuf.String(), "[INFO]")
+	iBuf.Reset()
+
+	l.Infof(f, v...)
+	assert.Contains(t, iBuf.String(), "[INFO]")
+	assert.Contains(t, iBuf.String(), "-")
+	iBuf.Reset()
+
+	l.Warn(v...)
+	assert.Contains(t, wBuf.String(), "[WARN]")
+	iBuf.Reset()
+
+	l.Warnf(f, v...)
+	assert.Contains(t, wBuf.String(), "[WARN]")
+	assert.Contains(t, wBuf.String(), "-")
+	iBuf.Reset()
+
+	l.Error(v...)
+	assert.Contains(t, eBuf.String(), "[ERROR]")
+	iBuf.Reset()
+
+	l.Errorf(f, v...)
+	assert.Contains(t, eBuf.String(), "[ERROR]")
+	assert.Contains(t, eBuf.String(), "-")
+	iBuf.Reset()
+}

--- a/internal/core/pipeline.go
+++ b/internal/core/pipeline.go
@@ -273,6 +273,9 @@ type Pipeline struct {
 
 	// Feature flags which enable the corresponding items.
 	features map[string]bool
+
+	// The logger for printing output.
+	l Logger
 }
 
 const (
@@ -318,8 +321,12 @@ func NewPipeline(repository *git.Repository) *Pipeline {
 		items:      []PipelineItem{},
 		facts:      map[string]interface{}{},
 		features:   map[string]bool{},
+		l:          NewLogger(),
 	}
 }
+
+// SetLogger updates the pipeline's logger.
+func (pipeline *Pipeline) SetLogger(l Logger) { pipeline.l = l }
 
 // GetFact returns the value of the fact with the specified name.
 func (pipeline *Pipeline) GetFact(name string) interface{} {

--- a/internal/core/pipeline.go
+++ b/internal/core/pipeline.go
@@ -552,7 +552,8 @@ func (pipeline *Pipeline) resolve(dumpPath string) {
 						}
 						fmt.Fprintln(os.Stderr, "]")
 					}
-					panic("Failed to resolve pipeline dependencies: ambiguous graph.")
+					pipeline.l.Critical("Failed to resolve pipeline dependencies: ambiguous graph.")
+					return
 				}
 				ambiguousMap[key] = graph.FindParents(key)
 			}
@@ -569,7 +570,7 @@ func (pipeline *Pipeline) resolve(dumpPath string) {
 		for _, key := range item.Requires() {
 			key = "[" + key + "]"
 			if graph.AddEdge(key, name) == 0 {
-				pipeline.l.Errorf("Unsatisfied dependency: %s -> %s", key, item.Name())
+				pipeline.l.Criticalf("Unsatisfied dependency: %s -> %s", key, item.Name())
 				return
 			}
 		}
@@ -623,7 +624,7 @@ func (pipeline *Pipeline) resolve(dumpPath string) {
 	}
 	strplan, ok := graph.Toposort()
 	if !ok {
-		pipeline.l.Errorf("Failed to resolve pipeline dependencies: unable to topologically sort the items.")
+		pipeline.l.Critical("Failed to resolve pipeline dependencies: unable to topologically sort the items.")
 		return
 	}
 	pipeline.items = make([]PipelineItem, 0, len(pipeline.items))
@@ -810,7 +811,7 @@ func (pipeline *Pipeline) Run(commits []*object.Commit) (map[LeafPipelineItem]in
 					val, ok := update[key]
 					if !ok {
 						err := fmt.Errorf("%s: Consume() did not return %s", item.Name(), key)
-						pipeline.l.Error(err)
+						pipeline.l.Critical(err)
 						return nil, err
 					}
 					state[key] = val

--- a/internal/core/pipeline.go
+++ b/internal/core/pipeline.go
@@ -658,11 +658,15 @@ func (pipeline *Pipeline) Initialize(facts map[string]interface{}) error {
 	if facts == nil {
 		facts = map[string]interface{}{}
 	}
+
+	// set logger from facts, otherwise set the pipeline's logger as the logger
+	// to be used by all analysis tasks by setting the fact
 	if l, exists := facts[ConfigLogger].(Logger); exists {
 		pipeline.l = l
 	} else {
 		facts[ConfigLogger] = pipeline.l
 	}
+
 	if _, exists := facts[ConfigPipelineCommits]; !exists {
 		var err error
 		facts[ConfigPipelineCommits], err = pipeline.Commits(false)

--- a/internal/core/pipeline.go
+++ b/internal/core/pipeline.go
@@ -336,9 +336,6 @@ func NewPipeline(repository *git.Repository) *Pipeline {
 	}
 }
 
-// SetLogger updates the pipeline's logger.
-func (pipeline *Pipeline) SetLogger(l Logger) { pipeline.l = l }
-
 // GetFact returns the value of the fact with the specified name.
 func (pipeline *Pipeline) GetFact(name string) interface{} {
 	return pipeline.facts[name]
@@ -657,6 +654,11 @@ func (pipeline *Pipeline) Initialize(facts map[string]interface{}) error {
 	}()
 	if facts == nil {
 		facts = map[string]interface{}{}
+	}
+	if l, exists := facts[ConfigLogger].(Logger); exists {
+		pipeline.l = l
+	} else {
+		facts[ConfigLogger] = pipeline.l
 	}
 	if _, exists := facts[ConfigPipelineCommits]; !exists {
 		var err error

--- a/internal/core/pipeline_test.go
+++ b/internal/core/pipeline_test.go
@@ -876,13 +876,15 @@ func TestPipelineRunHibernation(t *testing.T) {
 	}
 	pipeline.PrintActions = true
 	_, err := pipeline.Run(commits)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, item.Hibernated)
 	assert.True(t, item.Booted)
 	item.RaiseHibernateError = true
-	assert.Panics(t, func() { pipeline.Run(commits) })
+	_, err = pipeline.Run(commits)
+	assert.Error(t, err)
 	item.RaiseHibernateError = false
 	pipeline.Run(commits)
 	item.RaiseBootError = true
-	assert.Panics(t, func() { pipeline.Run(commits) })
+	_, err = pipeline.Run(commits)
+	assert.Error(t, err)
 }

--- a/internal/core/pipeline_test.go
+++ b/internal/core/pipeline_test.go
@@ -460,11 +460,12 @@ func TestPipelineDeps(t *testing.T) {
 	commits[0], _ = test.Repository.CommitObject(plumbing.NewHash(
 		"af9ddc0db70f09f3f27b4b98e415592a7485171c"))
 	result, err := pipeline.Run(commits)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, result[item1].(bool))
 	assert.Equal(t, result[item2], item2)
 	item1.TestNilConsumeReturn = true
-	assert.Panics(t, func() { pipeline.Run(commits) })
+	_, err = pipeline.Run(commits)
+	assert.Error(t, err)
 }
 
 func TestPipelineDeployFeatures(t *testing.T) {

--- a/internal/plumbing/diff.go
+++ b/internal/plumbing/diff.go
@@ -18,6 +18,8 @@ type FileDiff struct {
 	core.NoopMerger
 	CleanupDisabled  bool
 	WhitespaceIgnore bool
+
+	l core.Logger
 }
 
 const (
@@ -84,6 +86,11 @@ func (diff *FileDiff) ListConfigurationOptions() []core.ConfigurationOption {
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (diff *FileDiff) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
+		diff.l = l
+	} else {
+		diff.l = core.NewLogger()
+	}
 	if val, exists := facts[ConfigFileDiffDisableCleanup].(bool); exists {
 		diff.CleanupDisabled = val
 	}
@@ -96,6 +103,7 @@ func (diff *FileDiff) Configure(facts map[string]interface{}) error {
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
 func (diff *FileDiff) Initialize(repository *git.Repository) error {
+	diff.l = core.NewLogger()
 	return nil
 }
 

--- a/internal/plumbing/diff.go
+++ b/internal/plumbing/diff.go
@@ -88,8 +88,6 @@ func (diff *FileDiff) ListConfigurationOptions() []core.ConfigurationOption {
 func (diff *FileDiff) Configure(facts map[string]interface{}) error {
 	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
 		diff.l = l
-	} else {
-		diff.l = core.NewLogger()
 	}
 	if val, exists := facts[ConfigFileDiffDisableCleanup].(bool); exists {
 		diff.CleanupDisabled = val

--- a/internal/plumbing/diff_test.go
+++ b/internal/plumbing/diff_test.go
@@ -27,10 +27,11 @@ func TestFileDiffMeta(t *testing.T) {
 	assert.Len(t, fd.ListConfigurationOptions(), 2)
 	assert.Equal(t, fd.ListConfigurationOptions()[0].Name, items.ConfigFileDiffDisableCleanup)
 	assert.Equal(t, fd.ListConfigurationOptions()[1].Name, items.ConfigFileWhitespaceIgnore)
-	facts := map[string]interface{}{}
-	facts[items.ConfigFileDiffDisableCleanup] = true
-	facts[items.ConfigFileWhitespaceIgnore] = true
-	fd.Configure(facts)
+	assert.NoError(t, fd.Configure(map[string]interface{}{
+		core.ConfigLogger:                  core.NewLogger(),
+		items.ConfigFileDiffDisableCleanup: true,
+		items.ConfigFileWhitespaceIgnore:   true,
+	}))
 	assert.True(t, fd.CleanupDisabled)
 	assert.True(t, fd.WhitespaceIgnore)
 }

--- a/internal/plumbing/identity/identity.go
+++ b/internal/plumbing/identity/identity.go
@@ -21,6 +21,8 @@ type Detector struct {
 	PeopleDict map[string]int
 	// ReversedPeopleDict maps developer id -> description
 	ReversedPeopleDict []string
+
+	l core.Logger
 }
 
 const (
@@ -84,6 +86,11 @@ func (detector *Detector) ListConfigurationOptions() []core.ConfigurationOption 
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (detector *Detector) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
+		detector.l = l
+	} else {
+		detector.l = core.NewLogger()
+	}
 	if val, exists := facts[FactIdentityDetectorPeopleDict].(map[string]int); exists {
 		detector.PeopleDict = val
 	}
@@ -116,6 +123,7 @@ func (detector *Detector) Configure(facts map[string]interface{}) error {
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
 func (detector *Detector) Initialize(repository *git.Repository) error {
+	detector.l = core.NewLogger()
 	return nil
 }
 

--- a/internal/plumbing/identity/identity_test.go
+++ b/internal/plumbing/identity/identity_test.go
@@ -41,6 +41,11 @@ func TestIdentityDetectorMeta(t *testing.T) {
 	opts := id.ListConfigurationOptions()
 	assert.Len(t, opts, 1)
 	assert.Equal(t, opts[0].Name, ConfigIdentityDetectorPeopleDictPath)
+	logger := core.NewLogger()
+	assert.NoError(t, id.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, id.l)
 }
 
 func TestIdentityDetectorConfigure(t *testing.T) {

--- a/internal/plumbing/languages.go
+++ b/internal/plumbing/languages.go
@@ -15,6 +15,8 @@ import (
 // LanguagesDetection run programming language detection over the changed files.
 type LanguagesDetection struct {
 	core.NoopMerger
+
+	l core.Logger
 }
 
 const (
@@ -50,12 +52,18 @@ func (langs *LanguagesDetection) ListConfigurationOptions() []core.Configuration
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (langs *LanguagesDetection) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
+		langs.l = l
+	} else {
+		langs.l = core.NewLogger()
+	}
 	return nil
 }
 
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
 func (langs *LanguagesDetection) Initialize(repository *git.Repository) error {
+	langs.l = core.NewLogger()
 	return nil
 }
 

--- a/internal/plumbing/languages.go
+++ b/internal/plumbing/languages.go
@@ -54,8 +54,6 @@ func (langs *LanguagesDetection) ListConfigurationOptions() []core.Configuration
 func (langs *LanguagesDetection) Configure(facts map[string]interface{}) error {
 	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
 		langs.l = l
-	} else {
-		langs.l = core.NewLogger()
 	}
 	return nil
 }

--- a/internal/plumbing/languages_test.go
+++ b/internal/plumbing/languages_test.go
@@ -20,8 +20,13 @@ func TestLanguagesDetectionMeta(t *testing.T) {
 	assert.Equal(t, ls.Requires()[1], DependencyBlobCache)
 	opts := ls.ListConfigurationOptions()
 	assert.Len(t, opts, 0)
-	assert.Nil(t, ls.Configure(nil))
-	assert.Nil(t, ls.Initialize(nil))
+	assert.NoError(t, ls.Configure(nil))
+	logger := core.NewLogger()
+	assert.NoError(t, ls.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, ls.l)
+	assert.NoError(t, ls.Initialize(nil))
 }
 
 func TestLanguagesDetectionRegistration(t *testing.T) {

--- a/internal/plumbing/line_stats.go
+++ b/internal/plumbing/line_stats.go
@@ -14,6 +14,8 @@ import (
 // LinesStatsCalculator measures line statistics for each text file in the commit.
 type LinesStatsCalculator struct {
 	core.NoopMerger
+
+	l core.Logger
 }
 
 // LineStats holds the numbers of inserted, deleted and changed lines.
@@ -60,12 +62,16 @@ func (lsc *LinesStatsCalculator) ListConfigurationOptions() []core.Configuration
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (lsc *LinesStatsCalculator) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
+		lsc.l = l
+	}
 	return nil
 }
 
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
 func (lsc *LinesStatsCalculator) Initialize(repository *git.Repository) error {
+	lsc.l = core.NewLogger()
 	return nil
 }
 

--- a/internal/plumbing/line_stats_test.go
+++ b/internal/plumbing/line_stats_test.go
@@ -23,7 +23,9 @@ func TestLinesStatsMeta(t *testing.T) {
 	assert.Equal(t, ra.Requires()[1], items.DependencyBlobCache)
 	assert.Equal(t, ra.Requires()[2], items.DependencyFileDiff)
 	assert.Nil(t, ra.ListConfigurationOptions())
-	assert.Nil(t, ra.Configure(nil))
+	assert.NoError(t, ra.Configure(map[string]interface{}{
+		core.ConfigLogger: core.NewLogger(),
+	}))
 	for _, f := range ra.Fork(10) {
 		assert.Equal(t, f, ra)
 	}

--- a/internal/plumbing/renames.go
+++ b/internal/plumbing/renames.go
@@ -389,7 +389,7 @@ func (ra *RenameAnalysis) blobsAreClose(blob1 *CachedBlob, blob2 *CachedBlob) (b
 	cleanReturn := false
 	defer func() {
 		if !cleanReturn {
-			ra.l.Warnf("unclean return detected for blobs '%s' and '%s'\n",
+			ra.l.Warnf("\nunclean return detected for blobs '%s' and '%s'\n",
 				blob1.Hash.String(), blob2.Hash.String())
 		}
 	}()

--- a/internal/plumbing/renames_test.go
+++ b/internal/plumbing/renames_test.go
@@ -34,12 +34,17 @@ func TestRenameAnalysisMeta(t *testing.T) {
 	assert.Len(t, opts, 1)
 	assert.Equal(t, opts[0].Name, ConfigRenameAnalysisSimilarityThreshold)
 	ra.SimilarityThreshold = 0
-	facts := map[string]interface{}{}
-	facts[ConfigRenameAnalysisSimilarityThreshold] = 70
-	ra.Configure(facts)
+
+	assert.NoError(t, ra.Configure(map[string]interface{}{
+		ConfigRenameAnalysisSimilarityThreshold: 70,
+	}))
 	assert.Equal(t, ra.SimilarityThreshold, 70)
-	delete(facts, ConfigRenameAnalysisSimilarityThreshold)
-	ra.Configure(facts)
+
+	logger := core.NewLogger()
+	assert.NoError(t, ra.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, ra.l)
 	assert.Equal(t, ra.SimilarityThreshold, 70)
 }
 

--- a/internal/plumbing/ticks_test.go
+++ b/internal/plumbing/ticks_test.go
@@ -2,8 +2,6 @@ package plumbing
 
 import (
 	"bytes"
-	"log"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -189,15 +187,11 @@ func TestTicksSinceStartConsumeZero(t *testing.T) {
 	deps[core.DependencyCommit] = commit
 	deps[core.DependencyIndex] = 0
 	// print warning to log
-	myOutput := &bytes.Buffer{}
-	log.SetOutput(myOutput)
-	defer func() {
-		log.SetOutput(os.Stderr)
-	}()
+	var capture bytes.Buffer
+	tss.l.(*core.DefaultLogger).W.SetOutput(&capture)
 	res, err := tss.Consume(deps)
 	assert.Nil(t, err)
-	output := myOutput.String()
-	assert.Contains(t, output, "Warning")
+	output := capture.String()
 	assert.Contains(t, output, "cce947b98a050c6d356bc6ba95030254914027b1")
 	assert.Contains(t, output, "hercules")
 	// depending on where the contributor clones this project from, the remote

--- a/internal/plumbing/ticks_test.go
+++ b/internal/plumbing/ticks_test.go
@@ -31,7 +31,11 @@ func TestTicksSinceStartMeta(t *testing.T) {
 	assert.Equal(t, tss.Provides()[0], DependencyTick)
 	assert.Equal(t, len(tss.Requires()), 0)
 	assert.Len(t, tss.ListConfigurationOptions(), 1)
-	tss.Configure(map[string]interface{}{})
+	logger := core.NewLogger()
+	assert.NoError(t, tss.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, tss.l)
 }
 
 func TestTicksSinceStartRegistration(t *testing.T) {

--- a/internal/plumbing/tree_diff.go
+++ b/internal/plumbing/tree_diff.go
@@ -171,7 +171,7 @@ func (treediff *TreeDiff) Consume(deps map[string]interface{}) (map[string]inter
 	}
 	if !pass && treediff.previousCommit != plumbing.ZeroHash {
 		err := fmt.Errorf("%s > %s", treediff.previousCommit.String(), commit.Hash.String())
-		treediff.l.Error(err)
+		treediff.l.Critical(err)
 		return nil, err
 	}
 	tree, err := commit.Tree()

--- a/internal/plumbing/tree_diff.go
+++ b/internal/plumbing/tree_diff.go
@@ -29,6 +29,8 @@ type TreeDiff struct {
 	previousTree   *object.Tree
 	previousCommit plumbing.Hash
 	repository     *git.Repository
+
+	l core.Logger
 }
 
 const (
@@ -120,6 +122,9 @@ func (treediff *TreeDiff) ListConfigurationOptions() []core.ConfigurationOption 
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (treediff *TreeDiff) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
+		treediff.l = l
+	}
 	if val, exists := facts[ConfigTreeDiffEnableBlacklist].(bool); exists && val {
 		treediff.SkipFiles = facts[ConfigTreeDiffBlacklistedPrefixes].([]string)
 	}
@@ -142,6 +147,7 @@ func (treediff *TreeDiff) Configure(facts map[string]interface{}) error {
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
 func (treediff *TreeDiff) Initialize(repository *git.Repository) error {
+	treediff.l = core.NewLogger()
 	treediff.previousTree = nil
 	treediff.repository = repository
 	if treediff.Languages == nil {

--- a/internal/plumbing/tree_diff.go
+++ b/internal/plumbing/tree_diff.go
@@ -3,7 +3,6 @@ package plumbing
 import (
 	"fmt"
 	"io"
-	"log"
 	"path"
 	"regexp"
 	"strings"
@@ -171,7 +170,9 @@ func (treediff *TreeDiff) Consume(deps map[string]interface{}) (map[string]inter
 		}
 	}
 	if !pass && treediff.previousCommit != plumbing.ZeroHash {
-		log.Panicf("%s > %s", treediff.previousCommit.String(), commit.Hash.String())
+		err := fmt.Errorf("%s > %s", treediff.previousCommit.String(), commit.Hash.String())
+		treediff.l.Error(err)
+		return nil, err
 	}
 	tree, err := commit.Tree()
 	if err != nil {

--- a/internal/plumbing/tree_diff_test.go
+++ b/internal/plumbing/tree_diff_test.go
@@ -26,6 +26,11 @@ func TestTreeDiffMeta(t *testing.T) {
 	assert.Equal(t, td.Provides()[0], DependencyTreeChanges)
 	opts := td.ListConfigurationOptions()
 	assert.Len(t, opts, 4)
+	logger := core.NewLogger()
+	assert.NoError(t, td.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, td.l)
 }
 
 func TestTreeDiffConfigure(t *testing.T) {

--- a/internal/plumbing/uast/diff_refiner.go
+++ b/internal/plumbing/uast/diff_refiner.go
@@ -18,6 +18,8 @@ import (
 // optimal, choose the one which touches less AST nodes.
 type FileDiffRefiner struct {
 	core.NoopMerger
+
+	l core.Logger
 }
 
 // Name of this PipelineItem. Uniquely identifies the type, used for mapping keys, etc.
@@ -54,12 +56,16 @@ func (ref *FileDiffRefiner) ListConfigurationOptions() []core.ConfigurationOptio
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (ref *FileDiffRefiner) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
+		ref.l = l
+	}
 	return nil
 }
 
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
 func (ref *FileDiffRefiner) Initialize(repository *git.Repository) error {
+	ref.l = core.NewLogger()
 	return nil
 }
 

--- a/internal/plumbing/uast/diff_refiner_test.go
+++ b/internal/plumbing/uast/diff_refiner_test.go
@@ -37,6 +37,11 @@ func TestFileDiffRefinerMeta(t *testing.T) {
 	features := fd.Features()
 	assert.Len(t, features, 1)
 	assert.Equal(t, features[0], FeatureUast)
+	logger := core.NewLogger()
+	assert.NoError(t, fd.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, fd.l)
 }
 
 func TestFileDiffRefinerRegistration(t *testing.T) {

--- a/internal/plumbing/uast/uast_test.go
+++ b/internal/plumbing/uast/uast_test.go
@@ -60,6 +60,11 @@ func TestUASTExtractorMeta(t *testing.T) {
 	feats := exr.Features()
 	assert.Len(t, feats, 1)
 	assert.Equal(t, feats[0], FeatureUast)
+	logger := core.NewLogger()
+	assert.NoError(t, exr.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, exr.l)
 }
 
 func TestUASTExtractorConfiguration(t *testing.T) {
@@ -239,6 +244,11 @@ func TestUASTChangesMeta(t *testing.T) {
 	assert.Equal(t, ch.Requires()[1], items.DependencyTreeChanges)
 	opts := ch.ListConfigurationOptions()
 	assert.Len(t, opts, 0)
+	logger := core.NewLogger()
+	assert.NoError(t, ch.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, ch.l)
 }
 
 func TestUASTChangesRegistration(t *testing.T) {
@@ -369,6 +379,11 @@ func TestUASTChangesSaverMeta(t *testing.T) {
 	assert.Len(t, opts, 1)
 	assert.Equal(t, opts[0].Name, ConfigUASTChangesSaverOutputPath)
 	assert.Equal(t, chs.Flag(), "dump-uast-changes")
+	logger := core.NewLogger()
+	assert.NoError(t, chs.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, chs.l)
 }
 
 func TestUASTChangesSaverConfiguration(t *testing.T) {

--- a/leaves/burndown_test.go
+++ b/leaves/burndown_test.go
@@ -57,6 +57,11 @@ func TestBurndownMeta(t *testing.T) {
 	}
 	assert.Len(t, opts, matches)
 	assert.Equal(t, bd.Flag(), "burndown")
+	logger := core.NewLogger()
+	assert.NoError(t, bd.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, bd.l)
 }
 
 func TestBurndownConfigure(t *testing.T) {

--- a/leaves/comment_sentiment_test.go
+++ b/leaves/comment_sentiment_test.go
@@ -55,6 +55,11 @@ func TestCommentSentimentMeta(t *testing.T) {
 	}
 	assert.Len(t, opts, matches)
 	assert.Equal(t, sent.Flag(), "sentiment")
+	logger := core.NewLogger()
+	assert.NoError(t, sent.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, sent.l)
 }
 
 func TestCommentSentimentConfigure(t *testing.T) {

--- a/leaves/commits.go
+++ b/leaves/commits.go
@@ -23,6 +23,8 @@ type CommitsAnalysis struct {
 	commits []*CommitStat
 	// reversedPeopleDict references IdentityDetector.ReversedPeopleDict
 	reversedPeopleDict []string
+
+	l core.Logger
 }
 
 // CommitsResult is returned by CommitsAnalysis.Finalize() and carries the statistics
@@ -77,6 +79,9 @@ func (ca *CommitsAnalysis) ListConfigurationOptions() []core.ConfigurationOption
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (ca *CommitsAnalysis) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
+		ca.l = l
+	}
 	if val, exists := facts[identity.FactIdentityDetectorReversedPeopleDict].([]string); exists {
 		ca.reversedPeopleDict = val
 	}
@@ -96,6 +101,7 @@ func (ca *CommitsAnalysis) Description() string {
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
 func (ca *CommitsAnalysis) Initialize(repository *git.Repository) error {
+	ca.l = core.NewLogger()
 	return nil
 }
 

--- a/leaves/commits_test.go
+++ b/leaves/commits_test.go
@@ -28,6 +28,11 @@ func TestCommitsMeta(t *testing.T) {
 	opts := ca.ListConfigurationOptions()
 	assert.Len(t, opts, 0)
 	assert.Equal(t, ca.Flag(), "commits-stat")
+	logger := core.NewLogger()
+	assert.NoError(t, ca.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, ca.l)
 }
 
 func TestCommitsRegistration(t *testing.T) {

--- a/leaves/couples.go
+++ b/leaves/couples.go
@@ -219,7 +219,7 @@ func (couples *CouplesAnalysis) Finalize() interface{} {
 		if err != nil {
 			err := fmt.Errorf("cannot find file %s in commit %s: %v",
 				name, couples.lastCommit.Hash.String(), err)
-			couples.l.Error(err)
+			couples.l.Critical(err)
 			return err
 		}
 		blob := items.CachedBlob{Blob: file.Blob}
@@ -227,7 +227,7 @@ func (couples *CouplesAnalysis) Finalize() interface{} {
 		if err != nil {
 			err := fmt.Errorf("cannot read blob %s of file %s: %v",
 				blob.Hash.String(), name, err)
-			couples.l.Error(err)
+			couples.l.Critical(err)
 			return err
 		}
 		filesLines[i], _ = blob.CountLines()
@@ -312,7 +312,7 @@ func (couples *CouplesAnalysis) Deserialize(pbmessage []byte) (interface{}, erro
 	if len(message.FileCouples.Index) != len(message.FilesLines) {
 		err := fmt.Errorf("Couples PB message integrity violation: file_couples (%d) != file_lines (%d)",
 			len(message.FileCouples.Index), len(message.FilesLines))
-		couples.l.Error(err)
+		couples.l.Critical(err)
 		return nil, err
 	}
 	for i, v := range message.FilesLines {

--- a/leaves/couples.go
+++ b/leaves/couples.go
@@ -38,6 +38,8 @@ type CouplesAnalysis struct {
 	lastCommit *object.Commit
 	// reversedPeopleDict references IdentityDetector.ReversedPeopleDict
 	reversedPeopleDict []string
+
+	l core.Logger
 }
 
 // CouplesResult is returned by CouplesAnalysis.Finalize() and carries couples matrices from
@@ -99,6 +101,9 @@ func (couples *CouplesAnalysis) ListConfigurationOptions() []core.ConfigurationO
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (couples *CouplesAnalysis) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
+		couples.l = l
+	}
 	if val, exists := facts[identity.FactIdentityDetectorPeopleCount].(int); exists {
 		couples.PeopleNumber = val
 		couples.reversedPeopleDict = facts[identity.FactIdentityDetectorReversedPeopleDict].([]string)
@@ -121,6 +126,7 @@ func (couples *CouplesAnalysis) Description() string {
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
 func (couples *CouplesAnalysis) Initialize(repository *git.Repository) error {
+	couples.l = core.NewLogger()
 	couples.people = make([]map[string]int, couples.PeopleNumber+1)
 	for i := range couples.people {
 		couples.people[i] = map[string]int{}

--- a/leaves/couples_test.go
+++ b/leaves/couples_test.go
@@ -33,6 +33,11 @@ func TestCouplesMeta(t *testing.T) {
 	assert.Equal(t, c.Requires()[1], plumbing.DependencyTreeChanges)
 	assert.Equal(t, c.Flag(), "couples")
 	assert.Len(t, c.ListConfigurationOptions(), 0)
+	logger := core.NewLogger()
+	assert.NoError(t, c.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, c.l)
 }
 
 func TestCouplesRegistration(t *testing.T) {

--- a/leaves/devs.go
+++ b/leaves/devs.go
@@ -31,6 +31,8 @@ type DevsAnalysis struct {
 	ticks map[int]map[int]*DevTick
 	// reversedPeopleDict references IdentityDetector.ReversedPeopleDict
 	reversedPeopleDict []string
+
+	l core.Logger
 }
 
 // DevsResult is returned by DevsAnalysis.Finalize() and carries the daily statistics
@@ -92,6 +94,9 @@ func (devs *DevsAnalysis) ListConfigurationOptions() []core.ConfigurationOption 
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (devs *DevsAnalysis) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
+		devs.l = l
+	}
 	if val, exists := facts[ConfigDevsConsiderEmptyCommits].(bool); exists {
 		devs.ConsiderEmptyCommits = val
 	}
@@ -114,6 +119,7 @@ func (devs *DevsAnalysis) Description() string {
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
 func (devs *DevsAnalysis) Initialize(repository *git.Repository) error {
+	devs.l = core.NewLogger()
 	devs.ticks = map[int]map[int]*DevTick{}
 	devs.OneShotMergeProcessor.Initialize()
 	return nil

--- a/leaves/devs_test.go
+++ b/leaves/devs_test.go
@@ -41,6 +41,11 @@ func TestDevsMeta(t *testing.T) {
 	assert.Equal(t, d.ListConfigurationOptions()[0].Type, core.BoolConfigurationOption)
 	assert.Equal(t, d.ListConfigurationOptions()[0].Default, false)
 	assert.True(t, len(d.Description()) > 0)
+	logger := core.NewLogger()
+	assert.NoError(t, d.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, d.l)
 }
 
 func TestDevsRegistration(t *testing.T) {

--- a/leaves/file_history.go
+++ b/leaves/file_history.go
@@ -25,6 +25,8 @@ type FileHistoryAnalysis struct {
 	core.OneShotMergeProcessor
 	files      map[string]*FileHistory
 	lastCommit *object.Commit
+
+	l core.Logger
 }
 
 // FileHistoryResult is returned by Finalize() and represents the analysis result.
@@ -79,12 +81,16 @@ func (history *FileHistoryAnalysis) Description() string {
 
 // Configure sets the properties previously published by ListConfigurationOptions().
 func (history *FileHistoryAnalysis) Configure(facts map[string]interface{}) error {
+	if l, exists := facts[core.ConfigLogger].(core.Logger); exists {
+		history.l = l
+	}
 	return nil
 }
 
 // Initialize resets the temporary caches and prepares this PipelineItem for a series of Consume()
 // calls. The repository which is going to be analysed is supplied as an argument.
 func (history *FileHistoryAnalysis) Initialize(repository *git.Repository) error {
+	history.l = core.NewLogger()
 	history.files = map[string]*FileHistory{}
 	history.OneShotMergeProcessor.Initialize()
 	return nil

--- a/leaves/file_history.go
+++ b/leaves/file_history.go
@@ -3,7 +3,6 @@ package leaves
 import (
 	"fmt"
 	"io"
-	"log"
 	"sort"
 	"strings"
 
@@ -164,7 +163,8 @@ func (history *FileHistoryAnalysis) Finalize() interface{} {
 	files := map[string]FileHistory{}
 	fileIter, err := history.lastCommit.Files()
 	if err != nil {
-		log.Panicf("Failed to iterate files of %s", history.lastCommit.Hash.String())
+		history.l.Errorf("Failed to iterate files of %s", history.lastCommit.Hash.String())
+		return err
 	}
 	err = fileIter.ForEach(func(file *object.File) error {
 		if fh := history.files[file.Name]; fh != nil {
@@ -173,7 +173,8 @@ func (history *FileHistoryAnalysis) Finalize() interface{} {
 		return nil
 	})
 	if err != nil {
-		log.Panicf("Failed to iterate files of %s", history.lastCommit.Hash.String())
+		history.l.Errorf("Failed to iterate files of %s", history.lastCommit.Hash.String())
+		return err
 	}
 	return FileHistoryResult{Files: files}
 }

--- a/leaves/file_history_test.go
+++ b/leaves/file_history_test.go
@@ -32,6 +32,11 @@ func TestFileHistoryMeta(t *testing.T) {
 	assert.Equal(t, fh.Requires()[2], identity.DependencyAuthor)
 	assert.Len(t, fh.ListConfigurationOptions(), 0)
 	assert.Nil(t, fh.Configure(nil))
+	logger := core.NewLogger()
+	assert.NoError(t, fh.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, fh.l)
 }
 
 func TestFileHistoryRegistration(t *testing.T) {

--- a/leaves/research/typos.go
+++ b/leaves/research/typos.go
@@ -203,7 +203,7 @@ func (tdb *TyposDatasetBuilder) Consume(deps map[string]interface{}) (map[string
 		for _, n := range nodesAdded {
 			pos := uast.PositionsOf(n.(nodes.Object))
 			if pos.Start() == nil {
-				tdb.l.Infof("repo %s commit %s file %s adds identifier %s with no position",
+				tdb.l.Warnf("repo %s commit %s file %s adds identifier %s with no position",
 					tdb.remote, commit.String(), change.Change.To.Name,
 					n.(nodes.Object)["Name"].(nodes.String))
 				continue
@@ -216,7 +216,7 @@ func (tdb *TyposDatasetBuilder) Consume(deps map[string]interface{}) (map[string
 		for _, n := range nodesRemoved {
 			pos := uast.PositionsOf(n.(nodes.Object))
 			if pos.Start() == nil {
-				tdb.l.Infof("repo %s commit %s file %s removes identifier %s with no position",
+				tdb.l.Warnf("repo %s commit %s file %s removes identifier %s with no position",
 					tdb.remote, commit.String(), change.Change.To.Name,
 					n.(nodes.Object)["Name"].(nodes.String))
 				continue

--- a/leaves/research/typos_test.go
+++ b/leaves/research/typos_test.go
@@ -34,6 +34,11 @@ func TestTyposDatasetMeta(t *testing.T) {
 	assert.Equal(t, opts[0].Name, ConfigTyposDatasetMaximumAllowedDistance)
 	assert.Equal(t, opts[0].Type, core.IntConfigurationOption)
 	assert.Equal(t, tdb.Flag(), "typos-dataset")
+	logger := core.NewLogger()
+	assert.NoError(t, tdb.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, tdb.l)
 }
 
 func TestTyposDatasetRegistration(t *testing.T) {

--- a/leaves/shotness_test.go
+++ b/leaves/shotness_test.go
@@ -45,12 +45,18 @@ func TestShotnessMeta(t *testing.T) {
 	assert.Nil(t, sh.Configure(nil))
 	assert.Equal(t, sh.XpathStruct, DefaultShotnessXpathStruct)
 	assert.Equal(t, sh.XpathName, DefaultShotnessXpathName)
-	facts := map[string]interface{}{}
-	facts[ConfigShotnessXpathStruct] = "xpath!"
-	facts[ConfigShotnessXpathName] = "another!"
-	assert.Nil(t, sh.Configure(facts))
+	assert.NoError(t, sh.Configure(map[string]interface{}{
+		ConfigShotnessXpathStruct: "xpath!",
+		ConfigShotnessXpathName:   "another!",
+	}))
 	assert.Equal(t, sh.XpathStruct, "xpath!")
 	assert.Equal(t, sh.XpathName, "another!")
+
+	logger := core.NewLogger()
+	assert.NoError(t, sh.Configure(map[string]interface{}{
+		core.ConfigLogger: logger,
+	}))
+	assert.Equal(t, logger, sh.l)
 }
 
 func TestShotnessRegistration(t *testing.T) {


### PR DESCRIPTION
closes #244 

This PR allows something like the following: (*edit* no longer possible as of https://github.com/src-d/hercules/pull/262/commits/c92aaacc8b5498a6d9f9b5699a2aed9ea904f85b - a wrapper needs to be written around zap)

```go
package hercules_test

import (
	"go.uber.org/zap"
	gogit "gopkg.in/src-d/go-git.v4"
	"gopkg.in/src-d/hercules.v10"
)

func main() {
	repo, _ := gogit.PlainOpen(".")
	pipe := hercules.NewPipeline(repo)
	pipe.Initialize(map[string]interface{}{
                // custom logger
		hercules.ConfigLogger: zap.NewExample().Sugar(),
	})
}
```

I've added a `Logger` and `Config` variable for `facts` in package `internal/core`, and also added the logger to all pipeline items and replaced the log calls that i could find.

There are still a few calls to `panic` that I think we should try to remove in favour of `error`, but I noticed some tests actually assert that panics occur so I've tried not to change too much for now (notably `BurndownAnalysis`)