### PR TITLE
Include license in release archives for easier repackaging

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ build_script:
   - cd %GOPATH%\src\gopkg.in\src-d\hercules.v10
   - go get -v github.com/golang/dep/cmd/dep
   - make
-  - 7z a c:\gopath\src\gopkg.in\src-d\hercules.v10\hercules.win64.zip %GOPATH%\bin\hercules.exe
+  - 7z a c:\gopath\src\gopkg.in\src-d\hercules.v10\hercules.win64.zip %GOPATH%\bin\hercules.exe LICENSE.md
 
 test_script:
   - go get -v -t -d gopkg.in/src-d/hercules.v10/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,7 @@ jobs:
         - export PATH=$GOPATH/bin:$PATH
       after_success:
         - gzip -S .darwin_amd64.gz $GOPATH/bin/hercules
+        - tar -xzvf "$GOPATH/bin/hercules.darwin_amd64.tar.gz" $GOPATH/bin/hercules LICENSE.md
       script: skip
       install:
         - travis_retry make
@@ -105,7 +106,9 @@ jobs:
         provider: releases
         api_key:
           secure: $GITHUB_TOKEN
-        file: "$GOPATH/bin/hercules.darwin_amd64.gz"
+        file:
+          - "$GOPATH/bin/hercules.darwin_amd64.gz"
+          - "$GOPATH/bin/hercules.darwin_amd64.tar.gz"
         skip_cleanup: true
         on:
           tags: true
@@ -131,11 +134,14 @@ jobs:
         - cd ..
       after_success:
         - gzip -S .linux_amd64.gz $GOPATH/bin/hercules
+        - tar -xzvf "$GOPATH/bin/hercules.linux_amd64.tar.gz" $GOPATH/bin/hercules LICENSE.md
       deploy:
         - provider: releases
           api_key:
             secure: $GITHUB_TOKEN
-          file: "$GOPATH/bin/hercules.linux_amd64.gz"
+          file:
+            - "$GOPATH/bin/hercules.linux_amd64.gz"
+            - "$GOPATH/bin/hercules.linux_amd64.tar.gz"
           skip_cleanup: true
           on:
             tags: true


### PR DESCRIPTION
Also by using tarballs on darwin/linux (instead of plain gzip) the binary
name is preserved.