### PR TITLE
labours: set font size from in devs

### DIFF
--- a/python/labours/labours.py
+++ b/python/labours/labours.py
@@ -1327,6 +1327,7 @@ def show_devs(args, name, start_date, end_date, people, days):
 
     matplotlib, pyplot = import_pyplot(args.backend, args.style)
     pyplot.rcParams["figure.figsize"] = (32, 16)
+    pyplot.rcParams["font.size"] = args.font_size
     prop_cycle = pyplot.rcParams["axes.prop_cycle"]
     colors = prop_cycle.by_key()["color"]
     fig, axes = pyplot.subplots(final.shape[0], 1)
@@ -1347,18 +1348,18 @@ def show_devs(args, name, start_date, end_date, people, days):
         author = people[dev_i]
         ax.text(0.03, 0.5, author[:36] + (author[36:] and "..."),
                 horizontalalignment="right", verticalalignment="center",
-                transform=ax.transAxes, fontsize=14,
+                transform=ax.transAxes, fontsize=args.font_size,
                 color="black" if args.background == "white" else "white")
         ds = devstats[dev_i]
         stats = "%5d %8s %8s" % (ds[0], _format_number(ds[1] - ds[2]), _format_number(ds[3]))
         ax.text(0.97, 0.5, stats,
                 horizontalalignment="left", verticalalignment="center",
-                transform=ax.transAxes, fontsize=14, family="monospace",
+                transform=ax.transAxes, fontsize=args.font_size, family="monospace",
                 backgroundcolor=backgrounds[ds[1] <= ds[2]],
                 color="black" if args.background == "white" else "white")
     axes[0].text(0.97, 1.75, " cmts    delta  changed",
                  horizontalalignment="left", verticalalignment="center",
-                 transform=axes[0].transAxes, fontsize=14, family="monospace",
+                 transform=axes[0].transAxes, fontsize=args.font_size, family="monospace",
                  color="black" if args.background == "white" else "white")
     axes[-1].set_axis_on()
     target_num_labels = 12


### PR DESCRIPTION
In some cases `-m dev`, after all the time it took to compute the alignment, would produce results that do not fit the screen and have to be zoomed. 

But interactive zooming may fail with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte` even with `--pb`.

This change enables setting smaller font size from CLI and allows to mitigate that issue.

Examples produced with `labours -m devs --font-size 7` before and after in details

<details>

## Before

<img width="345" alt="Screen Shot 2019-06-16 at 12 21 01 AM" src="https://user-images.githubusercontent.com/5582506/59556943-d0c23680-8fcc-11e9-8bd6-b8f532e8f09b.png">


## After
<img width="356" alt="Screen Shot 2019-06-16 at 12 22 03 AM" src="https://user-images.githubusercontent.com/5582506/59556947-d9b30800-8fcc-11e9-8804-d88a17a6e1b2.png">

</details>