### PR TITLE
Fix bugs in old_vs_new visualization

### DIFF
--- a/python/labours/labours.py
+++ b/python/labours/labours.py
@@ -1512,14 +1512,14 @@ def show_old_vs_new(args, name, start_date, end_date, people, days):
     start_date = datetime(start_date.year, start_date.month, start_date.day)
     end_date = datetime.fromtimestamp(end_date)
     end_date = datetime(end_date.year, end_date.month, end_date.day)
-    new_lines = numpy.zeros((end_date - start_date).days + 1)
+    new_lines = numpy.zeros((end_date - start_date).days + 2)
     old_lines = numpy.zeros_like(new_lines)
     for day, devs in days.items():
         for stats in devs.values():
             new_lines[day] += stats.Added
             old_lines[day] += stats.Removed + stats.Changed
     resolution = 32
-    window = slepian(len(new_lines) // resolution, 0.5)
+    window = slepian(max(len(new_lines) // resolution,1), 0.5)
     new_lines = convolve(new_lines, window, "same")
     old_lines = convolve(old_lines, window, "same")
     matplotlib, pyplot = import_pyplot(args.backend, args.style)

--- a/python/labours/labours.py
+++ b/python/labours/labours.py
@@ -1519,7 +1519,7 @@ def show_old_vs_new(args, name, start_date, end_date, people, days):
             new_lines[day] += stats.Added
             old_lines[day] += stats.Removed + stats.Changed
     resolution = 32
-    window = slepian(max(len(new_lines) // resolution,1), 0.5)
+    window = slepian(max(len(new_lines) // resolution, 1), 0.5)
     new_lines = convolve(new_lines, window, "same")
     old_lines = convolve(old_lines, window, "same")
     matplotlib, pyplot = import_pyplot(args.backend, args.style)


### PR DESCRIPTION
This PR increases the time window of new_lines by a day to avoid an edge case of commits in the last day.

I did not explore the logic too deeply but I can confirm I have noticed a crash with error:
`IndexError: index 4 is out of bounds for axis 0 with size 4`

Where the `days` array has more values then initialised in the `new_lines` array.

The second fix in the PR is in in the `window` object which can sometimes lead to a 0 being passed to the `slepian` function and causing the window array to be empty and hence the next `convolve` functions crashes with a domain error caused by a 0 passed to the `log` within the function.

Both these bugs have been fixed and tested on ~50 internal repos  of varying sizes.