### PR TITLE
added pandas day alias to fix problem when using hercules with resolutions < 1 month

### DIFF
--- a/python/labours/modes/burndown.py
+++ b/python/labours/modes/burndown.py
@@ -328,7 +328,7 @@ def load_burndown(
         )
         daily[(last - start).days :] = 0
         # Resample the bands
-        aliases = {"year": "A", "month": "M"}
+        aliases = {"year": "A", "month": "M", "day": "D"}
         resample = aliases.get(resample, resample)
         periods = 0
         date_granularity_sampling = [start]
@@ -342,6 +342,11 @@ def load_burndown(
                 print("too loose resampling - by year, trying by month")
                 return load_burndown(
                     header, name, matrix, "month", report_survival=False
+                )
+            elif resample == "M":
+                print("too loose resampling - by month, trying by day")
+                return load_burndown(
+                    header, name, matrix, "day", report_survival=False
                 )
             else:
                 raise ValueError("Too loose resampling: %s. Try finer." % resample)


### PR DESCRIPTION
Not sure where to fix this but I was getting the following errors when running with values of `$DAYS < 30`

```
./hercules --sampling=$DAYS --granularity=$DAYS --burndown --first-parent --pb "$OLD_CWD" | labours -f pb -m burndown-project --output stack_plot.png
```

```
Running: burndown-project
         Ratio of survived lines
2 days                  0.947440
4 days                  0.917328
6 days                  0.915297
8 days                  0.915124
10 days                 0.915124
12 days                 0.915124
14 days                 0.915124
14 days                 0.915124
resampling to year, please wait...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 5108.77it/s]
too loose resampling - by year, trying by month
resampling to month, please wait...
Traceback (most recent call last):
  File "/usr/bin/labours", line 10, in <module>
    sys.exit(main())
  File "/usr/lib/python3.7/site-packages/labours/cli.py", line 449, in main
    modes[mode]()
  File "/usr/lib/python3.7/site-packages/labours/cli.py", line 204, in project_burndown
    interpolation_progress=True,
  File "/usr/lib/python3.7/site-packages/labours/modes/burndown.py", line 344, in load_burndown
    header, name, matrix, "month", report_survival=False
  File "/usr/lib/python3.7/site-packages/labours/modes/burndown.py", line 347, in load_burndown
    raise ValueError("Too loose resampling: %s. Try finer." % resample)
ValueError: Too loose resampling: M. Try finer.
```
the `pandas.date_range` `freq` argument accepts [a number of](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timeseries-offset-aliases) different time strings including `D` for day resolution, which is what I wanted for a small project of mine.
